### PR TITLE
Fix incorrect usage of Info Version

### DIFF
--- a/smoke-test.ps1
+++ b/smoke-test.ps1
@@ -1,5 +1,5 @@
 Write-Host "Download Swagger Petstore v3 OpenAPI spec`n" -ForegroundColor Green
-curl -O https://petstore3.swagger.io/api/v3/openapi.yaml
+Invoke-WebRequest -Uri https://petstore3.swagger.io/api/v3/openapi.yaml -OutFile ./openapi.yaml
 
 Write-Host "`nGenerate code`n" -ForegroundColor Green
 Set-Location src/Atc.Rest.ApiGenerator.CLI

--- a/src/Atc.Rest.ApiGenerator/Models/BaseProjectOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/BaseProjectOptions.cs
@@ -106,21 +106,7 @@ namespace Atc.Rest.ApiGenerator.Models
 
         private static string GetApiVersion(OpenApiDocument openApiDocument)
         {
-            if (openApiDocument.Info?.Version != null)
-            {
-                return openApiDocument.Info.Version switch
-                {
-                    "1" => "v1",
-                    "1.0" => "v1",
-                    "1.0.0" => "v1",
-                    "v1" => "v1",
-                    "v1.0" => "v1",
-                    "v1.0.0" => "v1",
-                    _ => openApiDocument.Info.Version.Replace(".", string.Empty, StringComparison.Ordinal)
-                };
-            }
-
-            return "v1";
+            return "api/v1";
         }
     }
 }

--- a/src/Atc.Rest.ApiGenerator/Models/BaseProjectOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/BaseProjectOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Atc.Rest.ApiGenerator.Helpers;
 using Microsoft.OpenApi.Models;
 
@@ -106,7 +107,8 @@ namespace Atc.Rest.ApiGenerator.Models
 
         private static string GetApiVersion(OpenApiDocument openApiDocument)
         {
-            return "api/v1";
+            var server = openApiDocument.Servers?.FirstOrDefault()?.Url;
+            return string.IsNullOrWhiteSpace(server) ? "api/v1" : server;
         }
     }
 }

--- a/src/Atc.Rest.ApiGenerator/Models/BaseProjectOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/BaseProjectOptions.cs
@@ -44,7 +44,7 @@ namespace Atc.Rest.ApiGenerator.Models
             ToolVersion = GenerateHelper.GetAtcToolVersion();
             ApiOptions = apiOptions;
 
-            ApiVersion = GetApiVersion(openApiDocument);
+            RouteBase = GetApiVersion(openApiDocument);
             ProjectName = string.IsNullOrEmpty(projectSuffixName)
                 ? projectPrefixName
                     .Replace(" ", ".", StringComparison.Ordinal)
@@ -97,7 +97,7 @@ namespace Atc.Rest.ApiGenerator.Models
 
         public string ProjectName { get; }
 
-        public string ApiVersion { get; }
+        public string RouteBase { get; }
 
         public bool IsForClient { get; }
 

--- a/src/Atc.Rest.ApiGenerator/Models/ClientCSharpApiProjectOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/ClientCSharpApiProjectOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Atc.Rest.ApiGenerator.Helpers;
 using Microsoft.OpenApi.Models;
 
@@ -75,21 +76,8 @@ namespace Atc.Rest.ApiGenerator.Models
 
         private static string GetApiVersion(OpenApiDocument openApiDocument)
         {
-            if (openApiDocument.Info?.Version != null)
-            {
-                return openApiDocument.Info.Version switch
-                {
-                    "1" => "v1",
-                    "1.0" => "v1",
-                    "1.0.0" => "v1",
-                    "v1" => "v1",
-                    "v1.0" => "v1",
-                    "v1.0.0" => "v1",
-                    _ => openApiDocument.Info.Version.Replace(".", string.Empty, StringComparison.Ordinal)
-                };
-            }
-
-            return "v1";
+            var server = openApiDocument.Servers?.FirstOrDefault()?.Url;
+            return string.IsNullOrWhiteSpace(server) ? "api/v1" : server;
         }
     }
 }

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorEndpointControllers.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorEndpointControllers.cs
@@ -71,7 +71,7 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
             classDeclaration =
                 classDeclaration.AddAttributeLists(
                     SyntaxAttributeListFactory.Create(nameof(ApiControllerAttribute)),
-                    SyntaxAttributeListFactory.CreateWithOneItemWithOneArgument(nameof(RouteAttribute), $"{ApiProjectOptions.ApiVersion}/{GetRouteSegment()}"))
+                    SyntaxAttributeListFactory.CreateWithOneItemWithOneArgument(nameof(RouteAttribute), $"{ApiProjectOptions.RouteBase}/{GetRouteSegment()}"))
                 .AddBaseListTypes(SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName(nameof(ControllerBase))))
                 .AddGeneratedCodeAttribute(ApiProjectOptions.ToolName, ApiProjectOptions.ToolVersion.ToString())
                 .WithLeadingTrivia(SyntaxDocumentationFactory.CreateForEndpoints(FocusOnSegmentName));
@@ -205,7 +205,7 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
                         ApiProjectOptions.ApiOptions.Generator.UseNullableReferenceTypes,
                         ApiProjectOptions.ProjectName,
                         FocusOnSegmentName,
-                        $"/api/{ApiProjectOptions.ApiVersion}{routePart}",
+                        $"/{ApiProjectOptions.RouteBase}{routePart}",
                         apiOperation.Key,
                         operationName,
                         hasSharedResponseContract,

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorEndpointControllers.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorEndpointControllers.cs
@@ -71,7 +71,7 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
             classDeclaration =
                 classDeclaration.AddAttributeLists(
                     SyntaxAttributeListFactory.Create(nameof(ApiControllerAttribute)),
-                    SyntaxAttributeListFactory.CreateWithOneItemWithOneArgument(nameof(RouteAttribute), $"api/{ApiProjectOptions.ApiVersion}/{GetRouteSegment()}"))
+                    SyntaxAttributeListFactory.CreateWithOneItemWithOneArgument(nameof(RouteAttribute), $"{ApiProjectOptions.ApiVersion}/{GetRouteSegment()}"))
                 .AddBaseListTypes(SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName(nameof(ControllerBase))))
                 .AddGeneratedCodeAttribute(ApiProjectOptions.ToolName, ApiProjectOptions.ToolVersion.ToString())
                 .WithLeadingTrivia(SyntaxDocumentationFactory.CreateForEndpoints(FocusOnSegmentName));

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/ApiClient/SyntaxGeneratorClientEndpoint.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/ApiClient/SyntaxGeneratorClientEndpoint.cs
@@ -376,7 +376,7 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.ApiClient
             var equalsClauseSyntax = SyntaxFactory.EqualsValueClause(
                 SyntaxFactory.InvocationExpression(
                         SyntaxMemberAccessExpressionFactory.Create(nameof(IHttpMessageFactory.FromTemplate), "httpMessageFactory"))
-                    .WithArgumentList(CreateOneStringArg($"/api/{ApiProjectOptions.ApiVersion}{ApiUrlPath}")));
+                    .WithArgumentList(CreateOneStringArg($"/{ApiProjectOptions.RouteBase}{ApiUrlPath}")));
 
             var requestBuilderSyntax = SyntaxFactory.LocalDeclarationStatement(
                 SyntaxFactory.VariableDeclaration(


### PR DESCRIPTION
This fixes issue #69

The idea behind all the changes here is to fix the incorrect usage of the Info Version according to the [specification documentation](https://swagger.io/specification/#info-object)

I also replaced hard coded route paths that start with `/api/[version]/xxx` to use what is specified in the OpenAPI spec [Servers property](https://swagger.io/specification/#server-object) if that is defined, otherwise default to `/api/v1/xxx` since that is what is being attempted in the `BaseProjectOptions` class

The documentation for the Server URL states:

> A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in {brackets}.

The [Swagger Online Editor](https://editor.swagger.io) using [Swagger Petstore v3 spec](https://petstore3.swagger.io/api/v3/openapi.yaml) generates a MVC API Controller like this:

```csharp
public class PetApiController : ControllerBase
{ 
    /// <summary>
    /// Add a new pet to the store
    /// </summary>
    /// <remarks>Add a new pet to the store</remarks>
    /// <param name="body">Create a new pet in the store</param>
    /// <response code="200">Successful operation</response>
    /// <response code="405">Invalid input</response>
    [HttpPost]
    [Route("/api/v3/pet")]
    [ValidateModelState]
    [SwaggerOperation("AddPet")]
    [SwaggerResponse(statusCode: 200, type: typeof(Pet), description: "Successful operation")]
    public virtual IActionResult AddPet([FromBody]Pet body)
    { 
        throw new NotImplementedException();
    }
}
```

Here is a screenshot of Swagger UI when running generated code using [Swagger Petstore v3 OpenAPI specifications document](https://petstore3.swagger.io/api/v3/openapi.yaml):

![atc-generated-petstore3](https://user-images.githubusercontent.com/710400/106511373-6d9e5400-64d0-11eb-95cf-f1b241ce91aa.png)
