### PR TITLE
Implement missing Servers drop down in Swagger UI

### DIFF
--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -68,13 +68,13 @@ namespace {fullNamespace}
                         Version = ""{document.Info?.Version}"",
                         Title = ""{document.Info?.Title}"",
                         Description = @""{document.Info?.Description}"",
-                        Contact = new OpenApiContact()
+                        Contact = new OpenApiContact
                         {{
                             Name = ""{document.Info?.Contact?.Name}"",{contactUrl}
                             Email = ""{document.Info?.Contact?.Email}"",
                         }},
                         TermsOfService = new Uri(""{document.Info?.TermsOfService}""),
-                        License = new OpenApiLicense()
+                        License = new OpenApiLicense
                         {{
                             Name = ""{document.Info?.License?.Name}"",{licenseUrl}
                         }},

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Atc.Rest.ApiGenerator.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.OpenApi.Models;
 

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -40,6 +40,12 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
                     : $@"
                             Url = new Uri(""{document.Info?.License?.Url}""),";
 
+            var termsOfService =
+                string.IsNullOrWhiteSpace(document.Info?.License?.Url?.ToString())
+                    ? string.Empty
+                    : $@"
+                        TermsOfService = new Uri(""{document.Info?.TermsOfService}""),";
+
             return $@"using System;
 using System.IO;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
@@ -72,8 +78,7 @@ namespace {fullNamespace}
                         {{
                             Name = ""{document.Info?.Contact?.Name}"",{contactUrl}
                             Email = ""{document.Info?.Contact?.Email}"",
-                        }},
-                        TermsOfService = new Uri(""{document.Info?.TermsOfService}""),
+                        }},{termsOfService}
                         License = new OpenApiLicense
                         {{
                             Name = ""{document.Info?.License?.Name}"",{licenseUrl}

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Atc.Rest.ApiGenerator.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.OpenApi.Models;
@@ -78,11 +81,32 @@ namespace {fullNamespace}
                         }},
                     }});
             }}
-
+{GetServersCode(document.Servers)}
             options.IncludeXmlComments(Path.ChangeExtension(GetType().Assembly.Location, ""xml""));
         }}
     }}
 }}";
+        }
+
+        private static string GetServersCode(IList<OpenApiServer> documentServers)
+        {
+            if (documentServers?.Any() != true)
+            {
+                return string.Empty;
+            }
+
+            const string spaces = "            ";
+            var sb = new StringBuilder();
+
+            foreach (var server in documentServers)
+            {
+                var code = $@"options.AddServer(new OpenApiServer {{ Url = ""{server.Url}"" }});";
+                sb.Append(Environment.NewLine)
+                    .Append(spaces)
+                    .Append(code);
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -22,7 +22,9 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
 
         public string GenerateCode()
             => SyntaxFactory
-                .ParseSyntaxTree(GetSyntaxTreeText())
+                .ParseSyntaxTree(
+                    GetSyntaxTreeText()
+                        .Replace("\"\"", "null", StringComparison.OrdinalIgnoreCase))
                 .GetCompilationUnitRoot()
                 .ToFullString();
 

--- a/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/SwaggerDocOptionsTests.cs
+++ b/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/SwaggerDocOptionsTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Atc.Rest.ApiGenerator.SyntaxGenerators.Api;
 using Microsoft.OpenApi.Models;
 using Xunit;
@@ -33,6 +35,11 @@ Some useful links:
                     Title = "Swagger Petstore - OpenAPI 3.0",
                     Version = "1.0.6",
                     TermsOfService = new Uri("http://swagger.io/terms/"),
+                },
+                Servers = new List<OpenApiServer>
+                {
+                    new() { Url = "/api/v2" },
+                    new() { Url = "/api/v3" },
                 },
             };
 
@@ -79,6 +86,13 @@ Some useful links:
                 code
                     .Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal)
                     .Replace(" ", string.Empty, StringComparison.Ordinal),
+                StringComparison.Ordinal);
+
+        [Fact]
+        public void GeneratedCode_Adds_Servers()
+            => Assert.Contains(
+                "options.AddServer(new OpenApiServer",
+                code,
                 StringComparison.Ordinal);
 
         [Fact]
@@ -129,5 +143,16 @@ Some useful links:
                 openApiDocument.Info.TermsOfService.ToString(),
                 code,
                 StringComparison.OrdinalIgnoreCase);
+
+        [Fact]
+        public void GeneratedCode_Should_Contain_Servers()
+            => openApiDocument
+                .Servers
+                .ToList()
+                .ForEach(
+                    server => Assert.Contains(
+                        server.Url,
+                        code,
+                        StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/SwaggerDocOptionsTests.cs
+++ b/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/SwaggerDocOptionsTests.cs
@@ -38,8 +38,8 @@ Some useful links:
                 },
                 Servers = new List<OpenApiServer>
                 {
-                    new() { Url = "/api/v2" },
-                    new() { Url = "/api/v3" },
+                    new () { Url = "/api/v2" },
+                    new () { Url = "/api/v3" },
                 },
             };
 


### PR DESCRIPTION
This resolves issue #70

The changes here makes sure that if the [Servers array](https://swagger.io/specification/#server-object) is defined in the OpenAPI spec then it should be rendered in Swagger UI as a drop down box

Here is a screenshot of running the generated code using the [Swagger Petstore v3 OpenAPI spec](https://petstore3.swagger.io/api/v3/openapi.yaml)
![atc-generated-petstore3-servers](https://user-images.githubusercontent.com/710400/106529167-58ceba00-64ea-11eb-8693-6764c82cd17f.png)