### PR TITLE
Fix ContentResult initialization

### DIFF
--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorContractResult.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorContractResult.cs
@@ -471,7 +471,10 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
                                                                             SyntaxFactory.Token(SyntaxKind.IntKeyword)),
                                                                         SyntaxMemberAccessExpressionFactory.Create(httpStatusCode.ToNormalizedString(), nameof(HttpStatusCode)))),
                                                                 SyntaxTokenFactory.Comma(),
-                                                                SyntaxMemberAccessExpressionFactory.Create(parameterName, "Content"),
+                                                                SyntaxFactory.AssignmentExpression(
+                                                                    SyntaxKind.SimpleAssignmentExpression,
+                                                                    SyntaxFactory.IdentifierName("Content"),
+                                                                    SyntaxFactory.IdentifierName(parameterName)),
                                                             })))))))))
                 .WithSemicolonToken(SyntaxTokenFactory.Semicolon());
         }


### PR DESCRIPTION
This resolves issue #78

The generated code for `ContentResult` initialization looks like this:

```csharp
new ContentResult { StatusCode = (int)HttpStatusCode.MethodNotAllowed, Content.message } 
```

The changes in this pull request will generates code like this:

```csharp
new ContentResult { StatusCode = (int)HttpStatusCode.MethodNotAllowed, Content = message }
```