### PR TITLE
Revert "Implement missing Servers drop down in Swagger UI"

### DIFF
--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -66,13 +66,13 @@ namespace {fullNamespace}
                         Version = ""{document.Info?.Version}"",
                         Title = ""{document.Info?.Title}"",
                         Description = @""{document.Info?.Description}"",
-                        Contact = new OpenApiContact()
+                        Contact = new OpenApiContact
                         {{
                             Name = ""{document.Info?.Contact?.Name}"",{contactUrl}
                             Email = ""{document.Info?.Contact?.Email}"",
                         }},
                         TermsOfService = new Uri(""{document.Info?.TermsOfService}""),
-                        License = new OpenApiLicense()
+                        License = new OpenApiLicense
                         {{
                             Name = ""{document.Info?.License?.Name}"",{licenseUrl}
                         }},

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -20,7 +20,9 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
 
         public string GenerateCode()
             => SyntaxFactory
-                .ParseSyntaxTree(GetSyntaxTreeText())
+                .ParseSyntaxTree(
+                    GetSyntaxTreeText()
+                        .Replace("\"\"", "null", StringComparison.OrdinalIgnoreCase))
                 .GetCompilationUnitRoot()
                 .ToFullString();
 

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
+using Atc.Rest.ApiGenerator.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.OpenApi.Models;
 
@@ -22,9 +20,7 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
 
         public string GenerateCode()
             => SyntaxFactory
-                .ParseSyntaxTree(
-                    GetSyntaxTreeText()
-                        .Replace("\"\"", "null", StringComparison.OrdinalIgnoreCase))
+                .ParseSyntaxTree(GetSyntaxTreeText())
                 .GetCompilationUnitRoot()
                 .ToFullString();
 
@@ -41,12 +37,6 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
                     ? string.Empty
                     : $@"
                             Url = new Uri(""{document.Info?.License?.Url}""),";
-
-            var termsOfService =
-                string.IsNullOrWhiteSpace(document.Info?.License?.Url?.ToString())
-                    ? string.Empty
-                    : $@"
-                        TermsOfService = new Uri(""{document.Info?.TermsOfService}""),";
 
             return $@"using System;
 using System.IO;
@@ -76,43 +66,23 @@ namespace {fullNamespace}
                         Version = ""{document.Info?.Version}"",
                         Title = ""{document.Info?.Title}"",
                         Description = @""{document.Info?.Description}"",
-                        Contact = new OpenApiContact
+                        Contact = new OpenApiContact()
                         {{
                             Name = ""{document.Info?.Contact?.Name}"",{contactUrl}
                             Email = ""{document.Info?.Contact?.Email}"",
-                        }},{termsOfService}
-                        License = new OpenApiLicense
+                        }},
+                        TermsOfService = new Uri(""{document.Info?.TermsOfService}""),
+                        License = new OpenApiLicense()
                         {{
                             Name = ""{document.Info?.License?.Name}"",{licenseUrl}
                         }},
                     }});
             }}
-{GetServersCode(document.Servers)}
+
             options.IncludeXmlComments(Path.ChangeExtension(GetType().Assembly.Location, ""xml""));
         }}
     }}
 }}";
-        }
-
-        private static string GetServersCode(IList<OpenApiServer> documentServers)
-        {
-            if (documentServers?.Any() != true)
-            {
-                return string.Empty;
-            }
-
-            const string spaces = "            ";
-            var sb = new StringBuilder();
-
-            foreach (var server in documentServers)
-            {
-                var code = $@"options.AddServer(new OpenApiServer {{ Url = ""{server.Url}"" }});";
-                sb.Append(Environment.NewLine)
-                    .Append(spaces)
-                    .Append(code);
-            }
-
-            return sb.ToString();
         }
     }
 }

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -38,6 +38,12 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
                     : $@"
                             Url = new Uri(""{document.Info?.License?.Url}""),";
 
+            var termsOfService =
+                string.IsNullOrWhiteSpace(document.Info?.License?.Url?.ToString())
+                    ? string.Empty
+                    : $@"
+                        TermsOfService = new Uri(""{document.Info?.TermsOfService}""),";
+
             return $@"using System;
 using System.IO;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
@@ -70,8 +76,7 @@ namespace {fullNamespace}
                         {{
                             Name = ""{document.Info?.Contact?.Name}"",{contactUrl}
                             Email = ""{document.Info?.Contact?.Email}"",
-                        }},
-                        TermsOfService = new Uri(""{document.Info?.TermsOfService}""),
+                        }},{termsOfService}
                         License = new OpenApiLicense
                         {{
                             Name = ""{document.Info?.License?.Name}"",{licenseUrl}

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorSwaggerDocOptions.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Atc.Rest.ApiGenerator.Helpers;
+﻿using System;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.OpenApi.Models;
 

--- a/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/SwaggerDocOptionsTests.cs
+++ b/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/SwaggerDocOptionsTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Atc.Rest.ApiGenerator.SyntaxGenerators.Api;
 using Microsoft.OpenApi.Models;
 using Xunit;
@@ -35,11 +33,6 @@ Some useful links:
                     Title = "Swagger Petstore - OpenAPI 3.0",
                     Version = "1.0.6",
                     TermsOfService = new Uri("http://swagger.io/terms/"),
-                },
-                Servers = new List<OpenApiServer>
-                {
-                    new () { Url = "/api/v2" },
-                    new () { Url = "/api/v3" },
                 },
             };
 
@@ -86,13 +79,6 @@ Some useful links:
                 code
                     .Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal)
                     .Replace(" ", string.Empty, StringComparison.Ordinal),
-                StringComparison.Ordinal);
-
-        [Fact]
-        public void GeneratedCode_Adds_Servers()
-            => Assert.Contains(
-                "options.AddServer(new OpenApiServer",
-                code,
                 StringComparison.Ordinal);
 
         [Fact]
@@ -143,16 +129,5 @@ Some useful links:
                 openApiDocument.Info.TermsOfService.ToString(),
                 code,
                 StringComparison.OrdinalIgnoreCase);
-
-        [Fact]
-        public void GeneratedCode_Should_Contain_Servers()
-            => openApiDocument
-                .Servers
-                .ToList()
-                .ForEach(
-                    server => Assert.Contains(
-                        server.Url,
-                        code,
-                        StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
Reverts atc-net/atc-rest-api-generator#76

After doing a thorough double check I noticed that using `AddServers()` has some other consequences to Swagger UI so even though the endpoint routes are created correct based on what is defined in the OpenAPI spec  `Servers` array, the behavior of using Swagger UI changed from prefixing the specified routes in code with the selected server from the drop down list

The Swagger UI generated cURL commands now look like this:
`curl -X GET "https://localhost:5001/api/v3/api/v3/pet/1?api-version=1.0" -H  "accept: application/json; v=1.0"`

I want to revert this change and find a better fix for it

UPDATE:
I manually cherry picked commits that include fixes for compiler warnings that I resolved in the original PR