### PR TITLE
Move project usings inside namespace. Closes #102

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -25,8 +25,9 @@ jobs:
         with:
           dotnet-version: '5.0.x'
 
-      - name: 🧹 Clean
-        run: dotnet clean -c Release && dotnet nuget locals all --clear
+      - name: 📐 Ensure nuget.org added as package source
+        if: matrix.os == 'windows-latest'
+        run: dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org --configfile $env:APPDATA\NuGet\NuGet.Config
 
       - name: 🔁 Restore packages
         run: dotnet restore
@@ -87,8 +88,9 @@ jobs:
         with:
           dotnet-version: '5.0.x'
 
-      - name: 🧹 Clean
-        run: dotnet clean -c Release && dotnet nuget locals all --clear
+      - name: 📐 Ensure nuget.org added as package source
+        if: matrix.os == 'windows-latest'
+        run: dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org --configfile $env:APPDATA\NuGet\NuGet.Config
 
       - name: 🔁 Restore packages
         run: dotnet restore

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   dotnet5-build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -64,6 +65,7 @@ jobs:
 
   smoke-tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           dotnet-version: '5.0.x'
 
-      - name: 📐 Ensure nuget.org added as package source
+      - name: 📐 Ensure nuget.org added as package source on Windows
         if: matrix.os == 'windows-latest'
         run: dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget.org --configfile $env:APPDATA\NuGet\NuGet.Config
+        continue-on-error: true
 
       - name: 🔁 Restore packages
         run: dotnet restore

--- a/src/Atc.Rest.ApiGenerator/Factories/ProjectApiFactory.cs
+++ b/src/Atc.Rest.ApiGenerator/Factories/ProjectApiFactory.cs
@@ -3,18 +3,35 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Atc.Rest.ApiGenerator.Models;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 
 namespace Atc.Rest.ApiGenerator.Factories
 {
     public static class ProjectApiFactory
     {
-        public static string[] CreateUsingListForEndpoint(
+        public static UsingDirectiveSyntax[] CreateProjectUsingListForEndpoint(
             ApiProjectOptions apiProjectOptions,
             string focusOnSegmentName,
+            bool hasSharedResponseContract)
+        {
+            var result = new List<UsingDirectiveSyntax>();
+
+            if (hasSharedResponseContract)
+            {
+                result.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName($"{apiProjectOptions.ProjectName}.{NameConstants.Contracts}")));
+            }
+
+            result.Add(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName($"{apiProjectOptions.ProjectName}.{NameConstants.Contracts}.{focusOnSegmentName.EnsureFirstCharacterToUpper()}")));
+
+            return result.ToArray();
+        }
+
+        public static string[] CreateGeneralUsingListForEndpoint(
+            ApiProjectOptions apiProjectOptions,
             List<OpenApiOperation> apiOperations,
-            bool includeRestResults,
-            bool hasSharedModel)
+            bool includeRestResults)
         {
             if (apiOperations == null)
             {
@@ -33,13 +50,6 @@ namespace Atc.Rest.ApiGenerator.Factories
             {
                 list.Add("Atc.Rest.Results");
             }
-
-            if (hasSharedModel)
-            {
-                list.Add($"{apiProjectOptions.ProjectName}.{NameConstants.Contracts}");
-            }
-
-            list.Add($"{apiProjectOptions.ProjectName}.{NameConstants.Contracts}.{focusOnSegmentName.EnsureFirstCharacterToUpper()}");
 
             list.Add("Microsoft.AspNetCore.Http");
             list.Add("Microsoft.AspNetCore.Mvc");

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorEndpointControllers.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Api/SyntaxGeneratorEndpointControllers.cs
@@ -104,6 +104,13 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
             }
 
             // Add the class to the namespace.
+            @namespace = @namespace.AddUsings(
+                ProjectApiFactory.CreateProjectUsingListForEndpoint(
+                    ApiProjectOptions,
+                    FocusOnSegmentName,
+                    HasSharedResponseContract()));
+
+            // Add the class to the namespace.
             @namespace = @namespace.AddMembers(classDeclaration);
 
             // Add using statement to compilationUnit
@@ -112,12 +119,10 @@ namespace Atc.Rest.ApiGenerator.SyntaxGenerators.Api
                 .Any(x => x.Identifier.ValueText.Contains($"({Microsoft.OpenApi.Models.NameConstants.Pagination}<", StringComparison.Ordinal));
 
             compilationUnit = compilationUnit.AddUsingStatements(
-                ProjectApiFactory.CreateUsingListForEndpoint(
+                ProjectApiFactory.CreateGeneralUsingListForEndpoint(
                     ApiProjectOptions,
-                    FocusOnSegmentName,
                     usedApiOperations,
-                    includeRestResults,
-                    HasSharedResponseContract()));
+                    includeRestResults));
 
             // Add namespace to compilationUnit
             compilationUnit = compilationUnit.AddMembers(@namespace);

--- a/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/Api/XUnitTestData/EndpointControllers/endpointWithContractWithConflictingName.verified.cs
+++ b/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/Api/XUnitTestData/EndpointControllers/endpointWithContractWithConflictingName.verified.cs
@@ -13,37 +13,37 @@ using Microsoft.AspNetCore.Mvc;
 //------------------------------------------------------------------------------
 namespace TestProject.AtcTest.Endpoints
 {
-    using TestProject.AtcTest.Contracts.Items;
+    using TestProject.AtcTest.Contracts.Tasks;
 
     /// <summary>
     /// Endpoint definitions.
-    /// Area: Items.
+    /// Area: Tasks.
     /// </summary>
     [ApiController]
-    [Route("/api/v1/items")]
+    [Route("/api/v1/tasks")]
     [GeneratedCode("ApiGenerator", "x.x.x.x")]
-    public class ItemsController : ControllerBase
+    public class TasksController : ControllerBase
     {
         /// <summary>
-        /// Description: Get item by id.
-        /// Operation: GetItemById.
-        /// Area: Items.
+        /// Description: Get.
+        /// Operation: Get.
+        /// Area: Tasks.
         /// </summary>
-        [HttpGet("{id}")]
-        [ProducesResponseType(typeof(Item), StatusCodes.Status200OK)]
-        public Task<ActionResult> GetItemByIdAsync(GetItemByIdParameters parameters, [FromServices] IGetItemByIdHandler handler, CancellationToken cancellationToken)
+        [HttpGet]
+        [ProducesResponseType(typeof(Task), StatusCodes.Status200OK)]
+        public Task<ActionResult> GetAsync([FromServices] IGetHandler handler, CancellationToken cancellationToken)
         {
             if (handler is null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return InvokeGetItemByIdAsync(parameters, handler, cancellationToken);
+            return InvokeGetAsync(handler, cancellationToken);
         }
 
-        private static async Task<ActionResult> InvokeGetItemByIdAsync(GetItemByIdParameters parameters, IGetItemByIdHandler handler, CancellationToken cancellationToken)
+        private static async Task<ActionResult> InvokeGetAsync([FromServices] IGetHandler handler, CancellationToken cancellationToken)
         {
-            return await handler.ExecuteAsync(parameters, cancellationToken);
+            return await handler.ExecuteAsync(cancellationToken);
         }
     }
 }

--- a/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/Api/XUnitTestData/EndpointControllers/endpointWithContractWithConflictingName.yaml
+++ b/test/Atc.Rest.ApiGenerator.Tests/SyntaxGenerators/Api/XUnitTestData/EndpointControllers/endpointWithContractWithConflictingName.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+paths:
+  '/tasks':
+    get:
+      summary: Get
+      description: Get
+      operationId: get
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+components:
+  schemas:
+    Task:
+      title: Task
+      description: Task.
+      type: object
+      properties:
+        id:
+          type: string


### PR DESCRIPTION
This is an implementation of the proposed solution in #102. 

This moves the project related using statements for a controller class inside the namespace declaration. That way, any contract models that conflicts with framework types are resolved by signaling to the compiler that the project contract models takes precedence. 