### PR TITLE
Fix OpenApi yaml validation output

### DIFF
--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
@@ -98,9 +98,9 @@ namespace Atc.Rest.ApiGenerator.Helpers
                 throw new ArgumentNullException(nameof(validationOptions));
             }
 
-            var logItems = new List<LogKeyValueItem>();
             if (apiDocument.Item2.Errors.Count > 0)
             {
+                var logItems = new List<LogKeyValueItem>();
                 foreach (var diagnosticError in apiDocument.Item2.Errors)
                 {
                     if (diagnosticError.Message.EndsWith("#/components/schemas", StringComparison.Ordinal))
@@ -123,25 +123,13 @@ namespace Atc.Rest.ApiGenerator.Helpers
 
             if (apiDocument.Item2.SpecificationVersion == OpenApiSpecVersion.OpenApi2_0)
             {
-                logItems.Add(LogItemHelper.Create(LogCategoryType.Error, "#", "OpenApi 2.x is not supported."));
-                return logItems;
-            }
-
-            foreach (var diagnosticError in apiDocument.Item2.Errors)
-            {
-                if (diagnosticError.Message.EndsWith("#/components/schemas", StringComparison.Ordinal))
+                return new List<LogKeyValueItem>
                 {
-                    continue;
-                }
-
-                var description = string.IsNullOrEmpty(diagnosticError.Pointer)
-                    ? $"{diagnosticError.Message}"
-                    : $"{diagnosticError.Message} <#> {diagnosticError.Pointer}";
-                logItems.Add(LogItemHelper.Create(LogCategoryType.Error, ValidationRuleNameConstants.OpenApiCore, description));
+                    LogItemHelper.Create(LogCategoryType.Error, "#", "OpenApi 2.x is not supported."),
+                };
             }
 
-            logItems.AddRange(OpenApiDocumentValidationHelper.ValidateDocument(apiDocument.Item1, validationOptions));
-            return logItems;
+            return OpenApiDocumentValidationHelper.ValidateDocument(apiDocument.Item1, validationOptions);
         }
 
         public static List<string> GetBasePathSegmentNames(OpenApiDocument openApiDocument)

--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
@@ -100,25 +100,17 @@ namespace Atc.Rest.ApiGenerator.Helpers
 
             if (apiDocument.Item2.Errors.Count > 0)
             {
-                var logItems = new List<LogKeyValueItem>();
-                foreach (var diagnosticError in apiDocument.Item2.Errors)
-                {
-                    if (diagnosticError.Message.EndsWith("#/components/schemas", StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
-
-                    var description = string.IsNullOrEmpty(diagnosticError.Pointer)
-                        ? $"{diagnosticError.Message}"
-                        : $"{diagnosticError.Message} <#> {diagnosticError.Pointer}";
-
-                    logItems.Add(LogItemHelper.Create(
+                return apiDocument.Item2.Errors
+                    .Where(e => !e.Message.EndsWith(
+                        "#/components/schemas",
+                        StringComparison.Ordinal))
+                    .Select(e => LogItemHelper.Create(
                         LogCategoryType.Error,
                         ValidationRuleNameConstants.OpenApiCore,
-                        description));
-                }
-
-                return logItems;
+                        string.IsNullOrEmpty(e.Pointer)
+                            ? $"{e.Message}"
+                            : $"{e.Message} <#> {e.Pointer}"))
+                    .ToList();
             }
 
             if (apiDocument.Item2.SpecificationVersion == OpenApiSpecVersion.OpenApi2_0)

--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
@@ -99,6 +99,28 @@ namespace Atc.Rest.ApiGenerator.Helpers
             }
 
             var logItems = new List<LogKeyValueItem>();
+            if (apiDocument.Item2.Errors.Count > 0)
+            {
+                foreach (var diagnosticError in apiDocument.Item2.Errors)
+                {
+                    if (diagnosticError.Message.EndsWith("#/components/schemas", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var description = string.IsNullOrEmpty(diagnosticError.Pointer)
+                        ? $"{diagnosticError.Message}"
+                        : $"{diagnosticError.Message} <#> {diagnosticError.Pointer}";
+
+                    logItems.Add(LogItemHelper.Create(
+                        LogCategoryType.Error,
+                        ValidationRuleNameConstants.OpenApiCore,
+                        description));
+                }
+
+                return logItems;
+            }
+
             if (apiDocument.Item2.SpecificationVersion == OpenApiSpecVersion.OpenApi2_0)
             {
                 logItems.Add(LogItemHelper.Create(LogCategoryType.Error, "#", "OpenApi 2.x is not supported."));


### PR DESCRIPTION
This PR fixes an issue where parsing errors of the input OpenApi yaml causes the `OpenApiSpecVersion` to default to `OpenApi2_0` and outputs the error as "OpenApi 2.x is not supported." instead of the actual error.

The suggested fix is to check for parsing errors first.