### PR TITLE
fix: Remove operationId plural validation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -514,3 +514,5 @@ dotnet_diagnostic.CA2254.severity = suggestion		# Template should be a static ex
 
 dotnet_diagnostic.S1172.severity = none				# False positive
 dotnet_diagnostic.S3267.severity = none				# Loop should be simplified by calling Select(x => x.Value)) - We dont like this rule because of readability/maintainability
+
+dotnet_diagnostic.SA1414.Severity = none			# Tuple types in signatures should have element names

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,7 @@
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
     <PackageReference Include="Meziantou.Analyzer" Version="1.0.701" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.2" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,10 +43,10 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.701" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.2" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.717" PrivateAssets="All" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.6" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.44.0.52574" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest.ApiGenerator.CLI/ApiOptionsHelper.cs
+++ b/src/Atc.Rest.ApiGenerator.CLI/ApiOptionsHelper.cs
@@ -96,6 +96,11 @@ public static class ApiOptionsHelper
             apiOptions.Validation.StrictMode = settings.StrictMode;
         }
 
+        if (settings.OperationIdValidation)
+        {
+            apiOptions.Validation.OperationIdValidation = settings.OperationIdValidation;
+        }
+
         if (settings.OperationIdCasingStyle.IsSet)
         {
             apiOptions.Validation.OperationIdCasingStyle = settings.OperationIdCasingStyle.Value;

--- a/src/Atc.Rest.ApiGenerator.CLI/AtcApiNugetClientHelper.cs
+++ b/src/Atc.Rest.ApiGenerator.CLI/AtcApiNugetClientHelper.cs
@@ -3,7 +3,7 @@ namespace Atc.Rest.ApiGenerator.CLI;
 public static class AtcApiNugetClientHelper
 {
     private const string BaseAddress = "https://atc-api.azurewebsites.net/nuget-search";
-    private static readonly ConcurrentDictionary<string, Version> Cache = new (StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, Version> Cache = new(StringComparer.Ordinal);
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
     public static Version? GetLatestVersionForPackageId(

--- a/src/Atc.Rest.ApiGenerator.CLI/Commands/ArgumentCommandConstants.cs
+++ b/src/Atc.Rest.ApiGenerator.CLI/Commands/ArgumentCommandConstants.cs
@@ -13,6 +13,7 @@ public static class ArgumentCommandConstants
     public const string LongConfigurationAuthorization = "--useAuthorization";
 
     public const string LongConfigurationValidateStrictMode = "--validate-strictMode";
+    public const string LongConfigurationValidateOperationIdValidation = "--validate-operationIdValidation";
     public const string LongConfigurationValidateOperationIdCasingStyle = "--validate-operationIdCasingStyle";
     public const string LongConfigurationValidateModelNameCasingStyle = "--validate-modelNameCasingStyle";
     public const string LongConfigurationValidateModelPropertyNameCasingStyle = "--validate-modelPropertyNameCasingStyle";

--- a/src/Atc.Rest.ApiGenerator.CLI/Commands/Settings/BaseConfigurationCommandSettings.cs
+++ b/src/Atc.Rest.ApiGenerator.CLI/Commands/Settings/BaseConfigurationCommandSettings.cs
@@ -14,17 +14,21 @@ public class BaseConfigurationCommandSettings : BaseCommandSettings
     [Description("Use strictmode")]
     public bool StrictMode { get; init; }
 
+    [CommandOption($"{ArgumentCommandConstants.LongConfigurationValidateOperationIdValidation}")]
+    [Description("Use operationId validation")]
+    public bool OperationIdValidation { get; init; }
+
     [CommandOption($"{ArgumentCommandConstants.LongConfigurationValidateOperationIdCasingStyle} [OPERATIONIDCASINGSTYLE]")]
     [CasingStyleDescription(Default = CasingStyle.CamelCase, Prefix = "Set casingStyle for operationId")]
-    public FlagValue<CasingStyle> OperationIdCasingStyle { get; init; } = new ();
+    public FlagValue<CasingStyle> OperationIdCasingStyle { get; init; } = new();
 
     [CommandOption($"{ArgumentCommandConstants.LongConfigurationValidateModelNameCasingStyle} [MODELNAMECASINGSTYLE]")]
     [CasingStyleDescription(Default = CasingStyle.PascalCase, Prefix = "Set casingStyle for model name")]
-    public FlagValue<CasingStyle> ModelNameCasingStyle { get; init; } = new ();
+    public FlagValue<CasingStyle> ModelNameCasingStyle { get; init; } = new();
 
     [CommandOption($"{ArgumentCommandConstants.LongConfigurationValidateModelPropertyNameCasingStyle} [MODELPROPERTYNAMECASINGSTYLE]")]
     [CasingStyleDescription(Default = CasingStyle.CamelCase, Prefix = "Set casingStyle for model property name")]
-    public FlagValue<CasingStyle> ModelPropertyNameCasingStyle { get; init; } = new ();
+    public FlagValue<CasingStyle> ModelPropertyNameCasingStyle { get; init; } = new();
 
     [CommandOption($"{ArgumentCommandConstants.LongConfigurationAuthorization}")]
     [Description("Use authorization")]

--- a/src/Atc.Rest.ApiGenerator/Extensions/PropertyDeclarationSyntaxExtensions.cs
+++ b/src/Atc.Rest.ApiGenerator/Extensions/PropertyDeclarationSyntaxExtensions.cs
@@ -109,7 +109,7 @@ internal static class PropertyDeclarationSyntaxExtensions
                 OpenApiFormatTypeConstants.Email => propertyDeclaration.AddValidationAttributeEmail(schema),
                 OpenApiFormatTypeConstants.Uri => propertyDeclaration.AddValidationAttribute(new UriAttribute()),
 
-                _ => throw new NotImplementedException($"Schema Format '{schema.Format}' must be implemented.")
+                _ => throw new NotImplementedException($"Schema Format '{schema.Format}' must be implemented."),
             };
         }
 
@@ -165,7 +165,7 @@ internal static class PropertyDeclarationSyntaxExtensions
             {
                 OpenApiDataTypeConstants.Number when !schema.HasFormatType() => RangeAttributeDouble(propertyDeclaration, schema),
                 OpenApiDataTypeConstants.Integer when schema.HasFormatType() && schema.IsFormatTypeInt64() => RangeAttributeLong(propertyDeclaration, schema),
-                _ => RangeAttributeInt(propertyDeclaration, schema)
+                _ => RangeAttributeInt(propertyDeclaration, schema),
             };
         }
 

--- a/src/Atc.Rest.ApiGenerator/Extensions/StringExtensions.cs
+++ b/src/Atc.Rest.ApiGenerator/Extensions/StringExtensions.cs
@@ -6,16 +6,16 @@ internal static class StringExtensions
 {
     private const string AutoPropGetSetResultPattern = " { get; set; }";
     private const string AutoPropGetResultPattern = " { get; }";
-    private static readonly Regex AutoPropGetSetRegex = new (@"\s*\{\s*get;\s*set;\s*}");
-    private static readonly Regex AutoPropGetRegex = new (@"\s*\{\s*get;\s*}");
-    private static readonly Regex AutoPropInitializerGetSetRegex = new (@"\s*\{ get; set; }\s*= \s*");
-    private static readonly Regex AutoPropInitializerGetRegex = new (@"\s*\{ get; }\s*= \s*");
-    private static readonly Regex AutoPublicLinesRegex = new (@"\s*;\s*public \s*");
-    private static readonly Regex AutoPrivateLinesRegex = new (@"\s*;\s*private \s*");
-    private static readonly Regex AutoCommentLinesRegex = new (@"\s*;\s*/// \s*");
-    private static readonly Regex AutoBracketSpacingStartRegex = new (@"(\S)({)(\S)");
-    private static readonly Regex AutoBracketSpacingEndRegex = new (@"(\S)(})(\S)");
-    private static readonly Regex ConstructorWithInheritResultRegex = new (@":\s*base\(result\)\s*\{\s*\}");
+    private static readonly Regex AutoPropGetSetRegex = new(@"\s*\{\s*get;\s*set;\s*}");
+    private static readonly Regex AutoPropGetRegex = new(@"\s*\{\s*get;\s*}");
+    private static readonly Regex AutoPropInitializerGetSetRegex = new(@"\s*\{ get; set; }\s*= \s*");
+    private static readonly Regex AutoPropInitializerGetRegex = new(@"\s*\{ get; }\s*= \s*");
+    private static readonly Regex AutoPublicLinesRegex = new(@"\s*;\s*public \s*");
+    private static readonly Regex AutoPrivateLinesRegex = new(@"\s*;\s*private \s*");
+    private static readonly Regex AutoCommentLinesRegex = new(@"\s*;\s*/// \s*");
+    private static readonly Regex AutoBracketSpacingStartRegex = new(@"(\S)({)(\S)");
+    private static readonly Regex AutoBracketSpacingEndRegex = new(@"(\S)(})(\S)");
+    private static readonly Regex ConstructorWithInheritResultRegex = new(@":\s*base\(result\)\s*\{\s*\}");
 
     private static readonly string[] LineBreaks = { "\r\n", "\r", "\n" };
 

--- a/src/Atc.Rest.ApiGenerator/Factories/SuppressMessageAttributeFactory.cs
+++ b/src/Atc.Rest.ApiGenerator/Factories/SuppressMessageAttributeFactory.cs
@@ -23,7 +23,7 @@ internal static class SuppressMessageAttributeFactory
         {
             // TODO: Add all rules
             1062 => new SuppressMessageAttribute("Design", "CA1062:Validate arguments of public methods") { Justification = justification },
-            _ => throw new NotImplementedException($"Rule for CA{checkId} must be implemented.")
+            _ => throw new NotImplementedException($"Rule for CA{checkId} must be implemented."),
         };
     }
 }

--- a/src/Atc.Rest.ApiGenerator/Helpers/AtcApiNugetClientHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/AtcApiNugetClientHelper.cs
@@ -3,7 +3,7 @@ namespace Atc.Rest.ApiGenerator.Helpers;
 public static class AtcApiNugetClientHelper
 {
     private const string BaseAddress = "https://atc-api.azurewebsites.net/nuget-search";
-    private static readonly ConcurrentDictionary<string, Version> Cache = new (StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, Version> Cache = new(StringComparer.Ordinal);
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
     public static Version? GetLatestVersionForPackageId(

--- a/src/Atc.Rest.ApiGenerator/Helpers/GenerateCodeHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/GenerateCodeHelper.cs
@@ -30,6 +30,6 @@ internal static class GenerateCodeHelper
             TrailingCharType.Comma => ",",
             TrailingCharType.SemiColon => ";",
             TrailingCharType.Colon => ":",
-            _ => throw new ArgumentOutOfRangeException(nameof(trailingChar), trailingChar, null)
+            _ => throw new ArgumentOutOfRangeException(nameof(trailingChar), trailingChar, null),
         };
 }

--- a/src/Atc.Rest.ApiGenerator/Helpers/GenerateHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/GenerateHelper.cs
@@ -6,7 +6,7 @@ namespace Atc.Rest.ApiGenerator.Helpers;
 
 public static class GenerateHelper
 {
-    private static readonly Version AtcToolVersion = new (1, 1, 405, 0); // TODO: Fix version
+    private static readonly Version AtcToolVersion = new(1, 1, 405, 0); // TODO: Fix version
 
     public static Version GetAtcVersion()
     {

--- a/src/Atc.Rest.ApiGenerator/Helpers/HttpClientHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/HttpClientHelper.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics;
-
 namespace Atc.Rest.ApiGenerator.Helpers;
 
 public static class HttpClientHelper
 {
-    private static readonly ConcurrentDictionary<string, string> Cache = new (StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, string> Cache = new(StringComparer.Ordinal);
 
     public static string GetAsString(
         ILogger logger,

--- a/src/Atc.Rest.ApiGenerator/Helpers/NugetPackageReferenceHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/NugetPackageReferenceHelper.cs
@@ -9,8 +9,8 @@ public static class NugetPackageReferenceHelper
 
         var packageReference = new List<Tuple<string, string, string?>>
         {
-            new ("Atc", atcVersion, null),
-            new ("Atc.Rest", atcVersion, null),
+            new("Atc", atcVersion, null),
+            new("Atc.Rest", atcVersion, null),
         };
 
         if (useRestExtended)
@@ -33,8 +33,8 @@ public static class NugetPackageReferenceHelper
 
         var packageReference = new List<Tuple<string, string, string?>>
         {
-            new ("Atc", atcVersion, null),
-            new ("Atc.Rest", atcVersion, null),
+            new("Atc", atcVersion, null),
+            new("Atc.Rest", atcVersion, null),
         };
 
         return packageReference;
@@ -46,8 +46,8 @@ public static class NugetPackageReferenceHelper
 
         var packageReference = new List<Tuple<string, string, string?>>
         {
-            new ("Atc", atcVersion, null),
-            new ("Atc.Rest.Client", "1.0.36", null),
+            new("Atc", atcVersion, null),
+            new("Atc.Rest.Client", "1.0.36", null),
         };
 
         return packageReference;
@@ -57,11 +57,11 @@ public static class NugetPackageReferenceHelper
     {
         var packageReference = new List<Tuple<string, string, string?>>
         {
-            new ("Atc.XUnit", "2.0.93", null),
-            new ("AutoFixture", "4.17.0", null),
-            new ("AutoFixture.AutoNSubstitute", "4.17.0", null),
-            new ("AutoFixture.Xunit2", "4.17.0", null),
-            new ("FluentAssertions", "6.5.1", null),
+            new("Atc.XUnit", "2.0.93", null),
+            new("AutoFixture", "4.17.0", null),
+            new("AutoFixture.AutoNSubstitute", "4.17.0", null),
+            new("AutoFixture.Xunit2", "4.17.0", null),
+            new("FluentAssertions", "6.5.1", null),
         };
 
         if (useMvc)
@@ -71,10 +71,10 @@ public static class NugetPackageReferenceHelper
 
         packageReference.AddRange(new List<Tuple<string, string, string?>>
         {
-            new ("Microsoft.NET.Test.Sdk", "17.1.0", null),
-            new ("NSubstitute", "4.3.0", null),
-            new ("xunit", "2.4.1", null),
-            new ("xunit.runner.visualstudio", "2.4.3", "<PrivateAssets>all</PrivateAssets>\n<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>"),
+            new("Microsoft.NET.Test.Sdk", "17.1.0", null),
+            new("NSubstitute", "4.3.0", null),
+            new("xunit", "2.4.1", null),
+            new("xunit.runner.visualstudio", "2.4.3", "<PrivateAssets>all</PrivateAssets>\n<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>"),
         });
 
         return packageReference;

--- a/src/Atc.Rest.ApiGenerator/Helpers/NugetPackageReferenceHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/NugetPackageReferenceHelper.cs
@@ -16,12 +16,12 @@ public static class NugetPackageReferenceHelper
         if (useRestExtended)
         {
             packageReference.Add(new Tuple<string, string, string?>("Atc.Rest.Extended", atcVersion, null));
-            packageReference.Add(new Tuple<string, string, string?>("FluentValidation.AspNetCore", "11.0.0", null));
-            packageReference.Add(new Tuple<string, string, string?>("Microsoft.ApplicationInsights.AspNetCore", "2.20.0", null));
-            packageReference.Add(new Tuple<string, string, string?>("Microsoft.AspNetCore.Authentication.JwtBearer", "6.0.4", null));
+            packageReference.Add(new Tuple<string, string, string?>("FluentValidation.AspNetCore", "11.1.3", null));
+            packageReference.Add(new Tuple<string, string, string?>("Microsoft.ApplicationInsights.AspNetCore", "2.21.0", null));
+            packageReference.Add(new Tuple<string, string, string?>("Microsoft.AspNetCore.Authentication.JwtBearer", "6.0.7", null));
             packageReference.Add(new Tuple<string, string, string?>("Microsoft.AspNetCore.Mvc.Versioning", "5.0.0", null));
             packageReference.Add(new Tuple<string, string, string?>("Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer", "5.0.0", null));
-            packageReference.Add(new Tuple<string, string, string?>("Swashbuckle.AspNetCore", "6.3.1", null));
+            packageReference.Add(new Tuple<string, string, string?>("Swashbuckle.AspNetCore", "6.4.0", null));
         }
 
         return packageReference;

--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentHelper.cs
@@ -61,7 +61,7 @@ public static class OpenApiDocumentHelper
             {
                 0 => throw new IOException("Api specification file don't exist in folder."),
                 1 => new FileInfo(docFiles.First()),
-                _ => CreateCombineApiDocumentFile(specificationPath)
+                _ => CreateCombineApiDocumentFile(specificationPath),
             };
         }
 

--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentValidationHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentValidationHelper.cs
@@ -239,31 +239,6 @@ public static class OpenApiDocumentValidationHelper
                     }
                 }
             }
-
-            foreach (var (operationKey, operationValue) in pathValue.Operations)
-            {
-                // Validate Response Schema
-                var responseModelSchema = operationValue.GetModelSchemaFromResponse();
-                if (responseModelSchema is not null)
-                {
-                    if (operationValue.IsOperationIdPluralized(operationKey))
-                    {
-                        if (!IsModelOfTypeArray(responseModelSchema, modelSchemas))
-                        {
-                            logItems.Add(LogItemHelper.Create(logCategory, ValidationRuleNameConstants.Operation08, $"OperationId '{operationValue.OperationId}' is not singular - Response model is defined as a single item."));
-                        }
-                    }
-                    else
-                    {
-                        if (IsModelOfTypeArray(responseModelSchema, modelSchemas))
-                        {
-                            logItems.Add(LogItemHelper.Create(logCategory, ValidationRuleNameConstants.Operation09, $"OperationId '{operationValue.OperationId}' is not pluralized - Response model is defined as an array."));
-                        }
-                    }
-                }
-
-                //// TO-DO Validate RequestBody Schema
-            }
         }
 
         return logItems;

--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentValidationHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentValidationHelper.cs
@@ -240,7 +240,33 @@ public static class OpenApiDocumentValidationHelper
                 }
             }
 
-            //// TO-DO Validate RequestBody Schema
+            if (validationOptions.OperationIdValidation)
+            {
+                foreach (var (operationKey, operationValue) in pathValue.Operations)
+                {
+                    // Validate Response Schema
+                    var responseModelSchema = operationValue.GetModelSchemaFromResponse();
+                    if (responseModelSchema is not null)
+                    {
+                        if (operationValue.IsOperationIdPluralized(operationKey))
+                        {
+                            if (!IsModelOfTypeArray(responseModelSchema, modelSchemas))
+                            {
+                                logItems.Add(LogItemHelper.Create(logCategory, ValidationRuleNameConstants.Operation08, $"OperationId '{operationValue.OperationId}' is not singular - Response model is defined as a single item."));
+                            }
+                        }
+                        else
+                        {
+                            if (IsModelOfTypeArray(responseModelSchema, modelSchemas))
+                            {
+                                logItems.Add(LogItemHelper.Create(logCategory, ValidationRuleNameConstants.Operation09, $"OperationId '{operationValue.OperationId}' is not pluralized - Response model is defined as an array."));
+                            }
+                        }
+                    }
+
+                    //// TO-DO Validate RequestBody Schema
+                }
+            }
         }
 
         return logItems;

--- a/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentValidationHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/OpenApiDocumentValidationHelper.cs
@@ -239,6 +239,8 @@ public static class OpenApiDocumentValidationHelper
                     }
                 }
             }
+
+            //// TO-DO Validate RequestBody Schema
         }
 
         return logItems;

--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateServerApiXunitTestEndpointTestHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateServerApiXunitTestEndpointTestHelper.cs
@@ -897,7 +897,7 @@ public static class GenerateServerApiXunitTestEndpointTestHelper
             "Uri" => ValueTypeTestPropertiesHelper.CreateValueUri(useForBadRequest),
             "Email" => ValueTypeTestPropertiesHelper.CreateValueEmail(useForBadRequest),
             "Array" when parameter.In == ParameterLocation.Query => ValueTypeTestPropertiesHelper.CreateValueArray(parameter.Name, parameter.Schema.Items, parameter.In, useForBadRequest, 3),
-            _ => PropertyValueGeneratorTypeResolver(parameter, componentsSchemas, useForBadRequest)
+            _ => PropertyValueGeneratorTypeResolver(parameter, componentsSchemas, useForBadRequest),
         };
     }
 

--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestPartsHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestPartsHelper.cs
@@ -470,7 +470,7 @@ public static class GenerateXunitTestPartsHelper
             "Guid" => ValueTypeTestPropertiesHelper.CreateValueGuid(useForBadRequest, itemNumber),
             "Uri" => ValueTypeTestPropertiesHelper.CreateValueUri(useForBadRequest),
             "Email" => ValueTypeTestPropertiesHelper.CreateValueEmail(useForBadRequest),
-            _ => PropertyValueGeneratorTypeResolver(schema, componentsSchemas, useForBadRequest)
+            _ => PropertyValueGeneratorTypeResolver(schema, componentsSchemas, useForBadRequest),
         };
     }
 

--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/ValueTypeTestPropertiesHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/ValueTypeTestPropertiesHelper.cs
@@ -43,7 +43,7 @@ public static class ValueTypeTestPropertiesHelper
         {
             OpenApiDataTypeConstants.Number when !schema.HasFormatType() => CreateNumberDouble(schema),
             OpenApiDataTypeConstants.Integer when schema.HasFormatType() && schema.IsFormatTypeInt64() => CreateNumberLong(schema),
-            _ => CreateNumberInt(schema)
+            _ => CreateNumberInt(schema),
         };
     }
 
@@ -335,6 +335,6 @@ public static class ValueTypeTestPropertiesHelper
             "Guid" => CreateValueGuid(useForBadRequest, itemNumber),
             "Uri" => CreateValueUri(useForBadRequest),
             "Email" => CreateValueEmail(useForBadRequest, itemNumber),
-            _ => throw new NotSupportedException($"PropertyValueGenerator: {name} - array of ({itemSchema.GetDataType()})")
+            _ => throw new NotSupportedException($"PropertyValueGenerator: {name} - array of ({itemSchema.GetDataType()})"),
         };
 }

--- a/src/Atc.Rest.ApiGenerator/Models/Options/ApiOptions.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/Options/ApiOptions.cs
@@ -2,7 +2,7 @@ namespace Atc.Rest.ApiGenerator.Models.Options;
 
 public class ApiOptions
 {
-    public ApiOptionsGenerator Generator { get; set; } = new ();
+    public ApiOptionsGenerator Generator { get; set; } = new();
 
-    public ApiOptionsValidation Validation { get; set; } = new ();
+    public ApiOptionsValidation Validation { get; set; } = new();
 }

--- a/src/Atc.Rest.ApiGenerator/Models/Options/ApiOptionsGenerator.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/Options/ApiOptionsGenerator.cs
@@ -8,7 +8,7 @@ public class ApiOptionsGenerator
 
     public bool UseRestExtended { get; set; } = true;
 
-    public ApiOptionsGeneratorRequest Request { get; set; } = new ();
+    public ApiOptionsGeneratorRequest Request { get; set; } = new();
 
-    public ApiOptionsGeneratorResponse Response { get; set; } = new ();
+    public ApiOptionsGeneratorResponse Response { get; set; } = new();
 }

--- a/src/Atc.Rest.ApiGenerator/Models/Options/ApiOptionsValidation.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/Options/ApiOptionsValidation.cs
@@ -6,6 +6,8 @@ public class ApiOptionsValidation
 {
     public bool StrictMode { get; set; }
 
+    public bool OperationIdValidation { get; set; }
+
     public CasingStyle OperationIdCasingStyle { get; set; } = CasingStyle.CamelCase;
 
     public CasingStyle ModelNameCasingStyle { get; set; } = CasingStyle.PascalCase;

--- a/src/Atc.Rest.ApiGenerator/ProjectSyntaxFactories/SyntaxDocumentationFactory.cs
+++ b/src/Atc.Rest.ApiGenerator/ProjectSyntaxFactories/SyntaxDocumentationFactory.cs
@@ -437,7 +437,7 @@ internal static class SyntaxDocumentationFactory
                 CreateComment("Url validation being enforced."),
                 CreateComment("</remarks>"),
             },
-            _ => SyntaxFactory.TriviaList()
+            _ => SyntaxFactory.TriviaList(),
         };
 
     private static bool ShouldGenerateDefaultSummary(

--- a/src/Atc.Rest.ApiGenerator/SyntaxFactories/SyntaxPropertyDeclarationFactory.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxFactories/SyntaxPropertyDeclarationFactory.cs
@@ -144,7 +144,7 @@ internal static class SyntaxPropertyDeclarationFactory
                 ParameterLocation.Header => propertyDeclaration.AddFromHeaderAttribute(parameter.Name, parameter.Schema),
                 ParameterLocation.Path => propertyDeclaration.AddFromRouteAttribute(parameter.Name, parameter.Schema),
                 ParameterLocation.Query => propertyDeclaration.AddFromQueryAttribute(parameter.Name, parameter.Schema),
-                _ => throw new NotImplementedException("ParameterLocation: " + nameof(ParameterLocation) + " " + parameter.In)
+                _ => throw new NotImplementedException("ParameterLocation: " + nameof(ParameterLocation) + " " + parameter.In),
             };
         }
 

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/ApiClient/SyntaxGeneratorClientEndpoint.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/ApiClient/SyntaxGeneratorClientEndpoint.cs
@@ -369,7 +369,7 @@ public class SyntaxGeneratorClientEndpoint : SyntaxGeneratorClientEndpointBase, 
             ParameterLocation.Query => nameof(IMessageRequestBuilder.WithQueryParameter),
             ParameterLocation.Header => nameof(IMessageRequestBuilder.WithHeaderParameter),
             ParameterLocation.Path => nameof(IMessageRequestBuilder.WithPathParameter),
-            _ => throw new NotSupportedException(nameof(parameter.In))
+            _ => throw new NotSupportedException(nameof(parameter.In)),
         };
 
         var parameterMapName = parameter.Name;

--- a/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Domain/SyntaxGeneratorHandler.cs
+++ b/src/Atc.Rest.ApiGenerator/SyntaxGenerators/Domain/SyntaxGeneratorHandler.cs
@@ -210,7 +210,8 @@ public class SyntaxGeneratorHandler
                     SyntaxFactory.Token(
                         CreatePragmaWarningCodeStyle1998(true),
                         SyntaxKind.PrivateKeyword,
-                        SyntaxFactory.TriviaList()), SyntaxFactory.Token(SyntaxKind.AsyncKeyword)))
+                        SyntaxFactory.TriviaList()),
+                    SyntaxFactory.Token(SyntaxKind.AsyncKeyword)))
             .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList<ParameterSyntax>(arguments)))
             .WithBody(
                 SyntaxFactory.Block(SyntaxThrowStatementFactory.CreateNotImplementedException())

--- a/test/Atc.Rest.ApiGenerator.Tests/CodeComplianceTests.cs
+++ b/test/Atc.Rest.ApiGenerator.Tests/CodeComplianceTests.cs
@@ -9,7 +9,7 @@ public class CodeComplianceTests
     private readonly Assembly sourceAssembly = typeof(AtcRestApiGeneratorAssemblyTypeInitializer).Assembly;
     private readonly Assembly testAssembly = typeof(CodeComplianceTests).Assembly;
 
-    private readonly List<Type> excludeTypes = new ()
+    private readonly List<Type> excludeTypes = new()
     {
         // TODO: Add UnitTest and remove from this list!!
         typeof(AtcApiNugetClientHelper),

--- a/test/Atc.Rest.ApiGenerator.Tests/CodeDocumentationTests.cs
+++ b/test/Atc.Rest.ApiGenerator.Tests/CodeDocumentationTests.cs
@@ -24,7 +24,8 @@ public class CodeDocumentationTests
         var codeDocPath =
             Path.Combine(
                 Path.Combine(
-                    Path.Combine(rootDirectory!.FullName, "docs"), "CodeDoc"), sourceAssembly.GetName().Name!);
+                    Path.Combine(rootDirectory!.FullName, "docs"), "CodeDoc"),
+                sourceAssembly.GetName().Name!);
         var codeDocDirectory = new DirectoryInfo(codeDocPath);
         if (!codeDocDirectory.Exists)
         {


### PR DESCRIPTION
Remove operationId plural validation as this in some cases prevents meaningful operationId naming.