### PR TITLE
fix: Escape regular expression patterns used in CSharp attributes

### DIFF
--- a/src/Atc.CodeGeneration.CSharp/Atc.CodeGeneration.CSharp.csproj
+++ b/src/Atc.CodeGeneration.CSharp/Atc.CodeGeneration.CSharp.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Atc" Version="2.0.349" />
     <PackageReference Include="Atc.CodeDocumentation" Version="2.0.349" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.CodeGeneration.CSharp/Content/Factories/AttributesParametersFactory.cs
+++ b/src/Atc.CodeGeneration.CSharp/Content/Factories/AttributesParametersFactory.cs
@@ -41,7 +41,8 @@ public static class AttributesParametersFactory
                     result.Add(new AttributeParameters("Range", $"{rangeAttribute.Minimum}, {rangeAttribute.Maximum}"));
                     break;
                 case RegularExpressionAttribute regularExpressionAttribute:
-                    result.Add(new AttributeParameters("RegularExpression", $"\"{regularExpressionAttribute.Pattern}\""));
+                    var escapedPattern = SymbolDisplay.FormatLiteral(regularExpressionAttribute.Pattern, true);
+                    result.Add(new AttributeParameters("RegularExpression", escapedPattern));
                     break;
                 case UriAttribute:
                     result.Add(new AttributeParameters("Uri", Content: null));

--- a/src/Atc.CodeGeneration.CSharp/Content/Factories/AttributesParametersFactory.cs
+++ b/src/Atc.CodeGeneration.CSharp/Content/Factories/AttributesParametersFactory.cs
@@ -41,7 +41,7 @@ public static class AttributesParametersFactory
                     result.Add(new AttributeParameters("Range", $"{rangeAttribute.Minimum}, {rangeAttribute.Maximum}"));
                     break;
                 case RegularExpressionAttribute regularExpressionAttribute:
-                    var escapedPattern = SymbolDisplay.FormatLiteral(regularExpressionAttribute.Pattern, true);
+                    var escapedPattern = SymbolDisplay.FormatLiteral(regularExpressionAttribute.Pattern, quote: true);
                     result.Add(new AttributeParameters("RegularExpression", escapedPattern));
                     break;
                 case UriAttribute:

--- a/src/Atc.CodeGeneration.CSharp/GlobalUsings.cs
+++ b/src/Atc.CodeGeneration.CSharp/GlobalUsings.cs
@@ -8,3 +8,5 @@ global using Atc.CodeDocumentation.CodeComment;
 global using Atc.CodeGeneration.CSharp.Content;
 global using Atc.CodeGeneration.CSharp.Content.Generators.Internal;
 global using Atc.CodeGeneration.CSharp.Extensions;
+
+global using Microsoft.CodeAnalysis.CSharp;


### PR DESCRIPTION
Patterns in specifications can contain characters that needs to be escaped in the CSharp generator when generating attributes.

Eg.:
```
ssn:
  type: string
  pattern: '^\d{3}-\d{2}-\d{4}$'
```

Currently generates:
`[RegularExpression("^\d{3}-\d{2}-\d{4}$")]`

But `\d` is an unrecognized escape sequence, this PR uses `Microsoft.CodeAnalysis.CSharp` to format the literal and produces:

`[RegularExpression("^\\d{3}-\\d{2}-\\d{4}$")]`